### PR TITLE
version bump to 2.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
 
 requirements:
   host:
-    - python >=3.6.1
+    - python
     - setuptools
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,8 @@ about:
   home: https://github.com/jupyter/kernel_gateway
   license: BSD-3-Clause
   license_file: LICENSE.md
+  license_family: BSD
+  license_url: https://opensource.org/licenses/BSD-3-Clause
   summary: Jupyter Kernel Gateway
   description: |
     Jupyter Kernel Gateway is a web server that provides headless access to Jupyter kernels.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,11 +46,6 @@ test:
     - jupyter-kernelgateway --help
     - jupyter kernelgateway --help
 
-extra:
-  skip-lints:
-    - missing_license_url
-    - missing_doc_source_url
-    
 about:
   home: https://github.com/jupyter/kernel_gateway
   license: BSD-3-Clause
@@ -69,3 +64,6 @@ extra:
     - parente
     - lresende
     - kevin-bates
+  skip-lints:
+    - missing_license_url
+    - missing_doc_source_url

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6.1
+    - python
     - jupyter_client >=5.2.0
     - jupyter_core >=4.4.0
     - notebook >=5.7.6,<7.0
@@ -45,12 +45,15 @@ test:
   commands:
     - jupyter-kernelgateway --help
     - jupyter kernelgateway --help
+    - pip check
 
 about:
-  home: http://github.com/jupyter/kernel_gateway
-  license: BSD 3-Clause
+  home: https://github.com/jupyter/kernel_gateway
+  license: BSD-3-Clause
   license_file: LICENSE.md
   summary: Jupyter Kernel Gateway
+  description: |
+    Jupyter Kernel Gateway is a web server that provides headless access to Jupyter kernels.
   doc_url: https://jupyter-kernel-gateway.readthedocs.io
   dev_url: https://github.com/jupyter/kernel_gateway
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,6 +56,7 @@ about:
   description: |
     Jupyter Kernel Gateway is a web server that provides headless access to Jupyter kernels.
   doc_url: https://jupyter-kernel-gateway.readthedocs.io
+  doc_source_url: https://github.com/jupyter-server/kernel_gateway/blob/master/docs/source/index.rst
   dev_url: https://github.com/jupyter/kernel_gateway
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,11 @@ test:
     - jupyter-kernelgateway --help
     - jupyter kernelgateway --help
 
+extra:
+  skip-lints:
+    - missing_license_url
+    - missing_doc_source_url
+    
 about:
   home: https://github.com/jupyter/kernel_gateway
   license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.5.0" %}
-{% set sha256 = "4e7b3ae544ae058edaf4cce4c985800fb6143291c4e9ed215539fd87a8966931" %}
+{% set version = "2.5.1" %}
+{% set sha256 = "1d40df18e1c5a346faf44716573dfd531343936bf479cb05e9391dbe28b90779" %}
 
 package:
   name: jupyter_kernel_gateway
@@ -12,7 +12,6 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: python setup.py install --single-version-externally-managed --record record.txt
   entry_points:
     - jupyter-kernelgateway = kernel_gateway:launch_instance
@@ -21,6 +20,7 @@ requirements:
   host:
     - python >=3.6.1
     - setuptools
+    - wheel
   run:
     - python >=3.6.1
     - jupyter_client >=5.2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,6 @@ test:
   commands:
     - jupyter-kernelgateway --help
     - jupyter kernelgateway --help
-    - pip check
 
 about:
   home: https://github.com/jupyter/kernel_gateway


### PR DESCRIPTION
# Version Bump to 2.5.1
- update sha256
- removed pinnings from python
- removed noarch
- added wheel
- a few amendments to about section

